### PR TITLE
Use render function to avoid compiling template.

### DIFF
--- a/vuejs-d3/src/components/NonVueLineChart.vue
+++ b/vuejs-d3/src/components/NonVueLineChart.vue
@@ -5,7 +5,9 @@ const data = [99, 71, 78, 25, 36, 92];
 
 export default {
   name: 'non-vue-line-chart',
-  template: '<div></div>',
+  render (h) {
+    return h('div')
+  },
   mounted() {
     const svg = d3.select(this.$el)
       .append('svg')
@@ -33,7 +35,7 @@ export default {
 
 <style lang="sass">
 svg
-  margin: 25px;
+  margin: 25px
   path
     fill: none
     stroke: #76BF8A


### PR DESCRIPTION
With these small changes, I could readily use the component as a toy example.
Now I'll move on to the vue-esque version of the d3-based component. Thanks for sharing!

References:

* https://vuejs.org/v2/guide/installation.html#Explanation-of-Different-Builds

* https://vuejs.org/v2/guide/render-function.html